### PR TITLE
fix overbroad list selector

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@ body {
 }
 
 
-li {
+nav li {
   list-style-type: none;
   display: inline;
   padding-right: 10px;


### PR DESCRIPTION
changes `li {}` to `nav li {}`
